### PR TITLE
Fix Problems with the Note-API.

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -21,7 +21,7 @@ class NotesController < ApplicationController
   def update
     note = Note.find(params[:id])
     if note.update_attributes(note_params)
-      render json: note, status: :success
+      render json: note
     else
       render json: render_errors(note), status: :unprocessable_entity
     end

--- a/spec/controllers/notes_controller_spec.rb
+++ b/spec/controllers/notes_controller_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe NotesController, type: :controller do
       get :show, params: { id: @note.id }
       json = JSON.parse(response.body)
       expect(json['id']).to eq(@note.id)
+      expect(response).to be_success
     end
 
     it "should include associated tags in response" do
@@ -91,6 +92,7 @@ RSpec.describe NotesController, type: :controller do
       json = JSON.parse(response.body)
       expect(json['content']).to eq('Updated this note.')
       expect(json['title']).to eq('Updated First')
+      expect(response).to be_success
     end
 
     it "should properly deal with validation errors" do


### PR DESCRIPTION
The lessons in the Note-API include a small problem.  

HTTP status codes with the number of `2xx` are generally considered `success`ful HTTP requests.  However, there is not a specific `:success` result (it's a blanket statement for any HTTP status code in the 200's).

Since `:success` isn't mapped to anything, including it causes problems.  Simply removing that will allow the HTTP request to automatically respond with a successful result.

This issue also should've been caught from our test suite.  This means, we should check the HTTP result in the test (without making the change in the controller, the test suite fails and shows that it falls back to a 500, since it doesn't know how to map `:success`).